### PR TITLE
Fix env.sh to properly export variables to parent shell

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -16,13 +16,20 @@ fi
 
 echo "Loading environment from $ENV_FILE..."
 
+# Enable auto-export of variables
+set -a
+
 # Load and export each variable
 while IFS= read -r line; do
   # Skip empty lines and comments
   if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
     echo "Setting: $line"
-    export "$line"
+    # Use eval to properly set the variable in current shell
+    eval "$line"
   fi
-done < "$ENV_FILE"
+done < <(grep -v '^[[:space:]]*#' "$ENV_FILE" | grep -v '^[[:space:]]*$')
+
+# Disable auto-export
+set +a
 
 echo "Environment loaded successfully!"


### PR DESCRIPTION
- Use process substitution to avoid subshell variable export issues
- Use set -a/+a to auto-export variables
- Use eval to properly set variables in current shell context
- Filter out comments and empty lines with grep


Change-ID: s95a27d27a0360eb3k