### PR TITLE
Fix air package path for Go hot reload

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -4,7 +4,7 @@ FROM golang:1.24.3-alpine
 WORKDIR /app
 
 # Install air for hot reload
-RUN go install github.com/cosmtrek/air@latest
+RUN go install github.com/air-verse/air@latest
 
 # Copy go mod files
 COPY go.mod go.sum ./


### PR DESCRIPTION
- Update from github.com/cosmtrek/air to github.com/air-verse/air
- Air tool moved repositories causing build failures


Change-ID: s16f863e6b139b288k