### PR TITLE
Fix backend mount permissions for uploads directory

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -22,7 +22,8 @@ services:
       context: ./backend
       dockerfile: Dockerfile.dev
     volumes:
-      - ./backend:/app:ro
+      - ./backend:/app
+      - ./uploads:/app/uploads
     command: go run main.go
     environment:
       - CGO_ENABLED=0


### PR DESCRIPTION
- Remove :ro flag from backend volume mount to allow writes
- Add separate uploads volume mount for file upload functionality
- Resolves read-only filesystem error when creating uploads directory


Change-ID: s0cf0456254d6280dk