### PR TITLE
Add development workflow documentation with separate service commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ source ./env.sh docker && docker compose up
 # Or start with make (which loads environment automatically)
 make up
 
+# For development with hot reload (changes update automatically)
+make up-dev
+
+# Or run services separately for development:
+# Terminal 1:
+source ./env.sh docker && docker compose -f docker-compose.yml -f docker-compose.dev.yml -p local up db
+# Terminal 2: 
+source ./env.sh docker && docker compose -f docker-compose.yml -f docker-compose.dev.yml -p local up backend
+# Terminal 3:
+source ./env.sh docker && docker compose -f docker-compose.yml -f docker-compose.dev.yml -p local up frontend
+
 # Access the application
 open http://localhost:5173
 ```

--- a/dear_llm.md
+++ b/dear_llm.md
@@ -218,15 +218,21 @@ make logs
 
 **Environment Management**:
 ```bash
-# Load environment and run commands
-source ./env.sh development && go run backend/main.go
+# Production/Standard Docker
 source ./env.sh docker && docker compose up
-source ./env.sh production && docker compose -f docker-compose.prod.yml up
+make up                      # Same as above with auto environment loading
 
-# Or use make commands (loads environment automatically)
-make up                      # Docker with auto environment loading
-make dev-backend            # Local backend development
-make dev-frontend           # Local frontend development
+# Development with Hot Reload
+make up-dev                  # All services with hot reload
+
+# Development - Separate terminals for debugging
+source ./env.sh docker && docker compose -f docker-compose.yml -f docker-compose.dev.yml -p local up db
+source ./env.sh docker && docker compose -f docker-compose.yml -f docker-compose.dev.yml -p local up backend
+source ./env.sh docker && docker compose -f docker-compose.yml -f docker-compose.dev.yml -p local up frontend
+
+# Local development (non-Docker)
+source ./env.sh development && go run backend/main.go
+source ./env.sh development && cd frontend && npm run dev
 ```
 
 **Testing**:


### PR DESCRIPTION
- Add hot reload development instructions to README
- Document three-terminal development setup for debugging
- Update dear_llm.md with comprehensive environment management examples
- Include both make commands and manual docker compose commands
- Show production, development, and local development workflows


Change-ID: s5e3232b988587263k