### PR TITLE
Fix modal closing when file picker opens

### DIFF
--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react'
 
-const FileUpload = ({ onUploadSuccess, projectName }) => {
+const FileUpload = ({ onUploadSuccess, projectName, onFilePickerOpen, onFilePickerClose }) => {
   const [file, setFile] = useState(null)
   const [uploadStatus, setUploadStatus] = useState('')
   const [isUploading, setIsUploading] = useState(false)
@@ -20,6 +20,7 @@ const FileUpload = ({ onUploadSuccess, projectName }) => {
   }
 
   const handleFileChange = (e) => {
+    onFilePickerClose?.()
     const selectedFile = e.target.files[0]
     handleFileSelect(selectedFile)
   }
@@ -100,8 +101,22 @@ const FileUpload = ({ onUploadSuccess, projectName }) => {
   }
 
   const handleButtonClick = () => {
+    onFilePickerOpen?.()
     fileInputRef.current?.click()
   }
+
+  // Handle focus returning to window (file picker closed)
+  useEffect(() => {
+    const handleFocus = () => {
+      // Small delay to ensure file change event fires first if file was selected
+      setTimeout(() => {
+        onFilePickerClose?.()
+      }, 50)
+    }
+
+    window.addEventListener('focus', handleFocus)
+    return () => window.removeEventListener('focus', handleFocus)
+  }, [onFilePickerClose])
 
   const formatFileSize = (bytes) => {
     if (bytes === 0) return '0 Bytes'

--- a/frontend/src/components/ProjectModal.jsx
+++ b/frontend/src/components/ProjectModal.jsx
@@ -5,6 +5,7 @@ const ProjectModal = ({ isOpen, onClose, onSave, project = null }) => {
   const [projectName, setProjectName] = useState('')
   const [selectedFile, setSelectedFile] = useState(null)
   const [isEditing, setIsEditing] = useState(false)
+  const [isFilePickerOpen, setIsFilePickerOpen] = useState(false)
   const modalRef = useRef(null)
   const nameInputRef = useRef(null)
 
@@ -44,6 +45,11 @@ const ProjectModal = ({ isOpen, onClose, onSave, project = null }) => {
     }
 
     const handleClickOutside = (e) => {
+      // Don't close modal if file picker is open
+      if (isFilePickerOpen) {
+        return
+      }
+      
       if (modalRef.current && !modalRef.current.contains(e.target)) {
         onClose()
       }
@@ -58,7 +64,7 @@ const ProjectModal = ({ isOpen, onClose, onSave, project = null }) => {
       document.removeEventListener('keydown', handleEscape)
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [isOpen, onClose])
+  }, [isOpen, onClose, isFilePickerOpen])
 
   const handleSubmit = (e) => {
     e.preventDefault()
@@ -117,6 +123,8 @@ const ProjectModal = ({ isOpen, onClose, onSave, project = null }) => {
               <FileUpload 
                 onUploadSuccess={handleFileUploadSuccess}
                 projectName={projectName}
+                onFilePickerOpen={() => setIsFilePickerOpen(true)}
+                onFilePickerClose={() => setIsFilePickerOpen(false)}
               />
             </div>
           )}


### PR DESCRIPTION
- Add file picker state tracking to prevent modal from closing
- Pass file picker callbacks from ProjectModal to FileUpload
- Disable click-outside detection when file picker is active
- Handle window focus events to detect when file picker closes
- Prevents modal from disappearing during file selection workflow


Change-ID: scc827b2dfae77cbdk