### PR TITLE
Fix missing useEffect import in FileUpload component

### DIFF
--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 
 const FileUpload = ({ onUploadSuccess, projectName, onFilePickerOpen, onFilePickerClose }) => {
   const [file, setFile] = useState(null)


### PR DESCRIPTION
- Add useEffect to React imports to resolve ReferenceError
- Required for window focus event listener functionality


Change-ID: sb24800b4633290c1k