### PR TITLE
Remove timeout-based file picker detection, use ref-based approach

### DIFF
--- a/frontend/src/components/FileUpload.jsx
+++ b/frontend/src/components/FileUpload.jsx
@@ -1,12 +1,13 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef } from 'react'
 
-const FileUpload = ({ onUploadSuccess, projectName, onFilePickerOpen, onFilePickerClose }) => {
+const FileUpload = ({ onUploadSuccess, projectName, fileInputRef }) => {
   const [file, setFile] = useState(null)
   const [uploadStatus, setUploadStatus] = useState('')
   const [isUploading, setIsUploading] = useState(false)
   const [isDragOver, setIsDragOver] = useState(false)
   const [uploadProgress, setUploadProgress] = useState(0)
-  const fileInputRef = useRef(null)
+  const internalFileInputRef = useRef(null)
+  const actualFileInputRef = fileInputRef || internalFileInputRef
 
   const handleFileSelect = (selectedFile) => {
     if (selectedFile && selectedFile.type === 'text/csv') {
@@ -20,7 +21,6 @@ const FileUpload = ({ onUploadSuccess, projectName, onFilePickerOpen, onFilePick
   }
 
   const handleFileChange = (e) => {
-    onFilePickerClose?.()
     const selectedFile = e.target.files[0]
     handleFileSelect(selectedFile)
   }
@@ -92,8 +92,8 @@ const FileUpload = ({ onUploadSuccess, projectName, onFilePickerOpen, onFilePick
         if (uploadStatus === 'success') {
           setFile(null)
           setUploadStatus('')
-          if (fileInputRef.current) {
-            fileInputRef.current.value = ''
+          if (actualFileInputRef.current) {
+            actualFileInputRef.current.value = ''
           }
         }
       }, 2000)
@@ -101,22 +101,8 @@ const FileUpload = ({ onUploadSuccess, projectName, onFilePickerOpen, onFilePick
   }
 
   const handleButtonClick = () => {
-    onFilePickerOpen?.()
-    fileInputRef.current?.click()
+    actualFileInputRef.current?.click()
   }
-
-  // Handle focus returning to window (file picker closed)
-  useEffect(() => {
-    const handleFocus = () => {
-      // Small delay to ensure file change event fires first if file was selected
-      setTimeout(() => {
-        onFilePickerClose?.()
-      }, 50)
-    }
-
-    window.addEventListener('focus', handleFocus)
-    return () => window.removeEventListener('focus', handleFocus)
-  }, [onFilePickerClose])
 
   const formatFileSize = (bytes) => {
     if (bytes === 0) return '0 Bytes'
@@ -156,7 +142,7 @@ const FileUpload = ({ onUploadSuccess, projectName, onFilePickerOpen, onFilePick
       </div>
       
       <input
-        ref={fileInputRef}
+        ref={actualFileInputRef}
         type="file"
         accept=".csv"
         onChange={handleFileChange}

--- a/frontend/src/components/ProjectModal.jsx
+++ b/frontend/src/components/ProjectModal.jsx
@@ -5,9 +5,9 @@ const ProjectModal = ({ isOpen, onClose, onSave, project = null }) => {
   const [projectName, setProjectName] = useState('')
   const [selectedFile, setSelectedFile] = useState(null)
   const [isEditing, setIsEditing] = useState(false)
-  const [isFilePickerOpen, setIsFilePickerOpen] = useState(false)
   const modalRef = useRef(null)
   const nameInputRef = useRef(null)
+  const fileInputRef = useRef(null)
 
   useEffect(() => {
     if (project) {
@@ -45,8 +45,8 @@ const ProjectModal = ({ isOpen, onClose, onSave, project = null }) => {
     }
 
     const handleClickOutside = (e) => {
-      // Don't close modal if file picker is open
-      if (isFilePickerOpen) {
+      // Don't close modal if click is on file input
+      if (fileInputRef.current && e.target === fileInputRef.current) {
         return
       }
       
@@ -64,7 +64,7 @@ const ProjectModal = ({ isOpen, onClose, onSave, project = null }) => {
       document.removeEventListener('keydown', handleEscape)
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [isOpen, onClose, isFilePickerOpen])
+  }, [isOpen, onClose])
 
   const handleSubmit = (e) => {
     e.preventDefault()
@@ -123,8 +123,7 @@ const ProjectModal = ({ isOpen, onClose, onSave, project = null }) => {
               <FileUpload 
                 onUploadSuccess={handleFileUploadSuccess}
                 projectName={projectName}
-                onFilePickerOpen={() => setIsFilePickerOpen(true)}
-                onFilePickerClose={() => setIsFilePickerOpen(false)}
+                fileInputRef={fileInputRef}
               />
             </div>
           )}


### PR DESCRIPTION
- Remove file picker state tracking and focus event listeners
- Pass file input ref from ProjectModal to FileUpload component
- Check for clicks on file input specifically in click-outside handler
- Simpler, more reliable approach without timing issues
- Remove unused useEffect import and callback props


Change-ID: s994865f4fe1283a1k