### PR TITLE
fix dropdown closing immediately on click

### DIFF
--- a/frontend/src/components/ExpenseRow.jsx
+++ b/frontend/src/components/ExpenseRow.jsx
@@ -121,6 +121,7 @@ const ExpenseRow = ({
         <select
           value={getCategoryValue(expense)}
           onChange={handleCategoryChange}
+          onClick={e => e.stopPropagation()}
         >
           <option value=""></option>
           {categories.map(category => {

--- a/frontend/src/components/ExpenseRow2.jsx
+++ b/frontend/src/components/ExpenseRow2.jsx
@@ -137,6 +137,7 @@ const ExpenseRow2 = ({
         <select
           value={getCategoryValue(currentExpense)}
           onChange={handleCategoryChange}
+          onClick={e => e.stopPropagation()}
           style={{ maxWidth: '220px' }}
         >
           <option value=""></option>


### PR DESCRIPTION
- add stopPropagation to select onClick in ExpenseRow.jsx
- add stopPropagation to select onClick in ExpenseRow2.jsx
- prevents dropdown click from bubbling to parent row onClick


Change-ID: s3e3a9d48c63b09a0k